### PR TITLE
Show the input file name in error messages.

### DIFF
--- a/comchap
+++ b/comchap
@@ -117,7 +117,7 @@ if [ ! -f "$edlfile" ]; then
   $comskipPath --ini="$comskipini" "$infile"
 
   if [ ! -f "$edlfile" ] ; then
-    echo "Error running comskip. EDL File not found."  1>&3 2>&4 >&2
+    echo "Error running comskip. EDL File not found: $infile"  1>&3 2>&4 >&2
     exitcode=-1
   fi
 fi
@@ -168,14 +168,14 @@ if $hascommercials ; then
       mv -f "$tempfile" "$outfile"
       echo Saved to: "$outfile"
     else
-      echo Error running ffmpeg. 1>&3 2>&4 >&2
+      echo Error running ffmpeg: "$infile" 1>&3 2>&4 >&2
       exitcode=-1
     fi
   else
     if $ffmpegPath -loglevel error -hide_banner -nostdin -i "$infile" -i "$metafile" -map_metadata 1 -codec copy -y "$outfile" 1>&3 2>&4; then
       echo Saved to: "$outfile"
     else
-      echo Error running ffmpeg. 1>&3 2>&4 >&2
+      echo Error running ffmpeg: "$infile" 1>&3 2>&4 >&2
       exitcode=-1
     fi
   fi
@@ -185,7 +185,7 @@ if $hascommercials ; then
     exitcode=-1
   fi
 else
-  echo No commercials found. 1>&3 2>&4 >&2
+  echo No commercials found: "$infile" 1>&3 2>&4 >&2
 fi
 
 if $deleteedl ; then


### PR DESCRIPTION
I was rewriting some of my own scripts and during testing I noticed it would be a lot nicer if comchap also displayed the input file when it output an error.  Minor change to allow this.