### PR TITLE
changed the if-then statements at the end for better results (for comcut)

### DIFF
--- a/comcut
+++ b/comcut
@@ -214,31 +214,31 @@ do
   rm "$i"
 done
 
-if $deleteedl ; then
+if [ "$deleteedl" == true ] ; then
   if [ -f "$edlfile" ] ; then
     rm "$edlfile";
   fi
 fi
 
-if $deletemeta ; then
+if [ "$deletemeta" == true ] ; then
   if [ -f "$metafile" ]; then
     rm "$metafile";
   fi
 fi
 
-if $deletelog ; then
+if [ "$deletelog" == true ] ; then
   if [ -f "$logfile" ]; then
     rm "$logfile";
   fi
 fi
 
-if $deletelogo ; then
+if [ "$deletelogo" == true ] ; then
   if [ -f "$logofile" ]; then
     rm "$logofile";
   fi
 fi
 
-if $deletetxt ; then
+if [ "$deletetxt" == true ] ; then
   if [ -f "$txtfile" ]; then
     rm "$txtfile";
   fi


### PR DESCRIPTION
now for comcut:

the if-then statements that flags if a file have to be kept or removed are not working in all situations.
in my case on Ubuntu 18.10 and bash version 4.3.48(1)-release (x86_64-pc-linux-gnu) i had false positives.
see also https://stackoverflow.com/questions/2953646/how-to-declare-and-use-boolean-variables-in-shell-script

in this pull request i changed the statements that way.