### PR TITLE
Add quotation marks around filename references

### DIFF
--- a/comcut
+++ b/comcut
@@ -68,14 +68,14 @@ case $key in
     exit 1
     ;;
     *)
-    if [ -z $infile ]; then
+    if [ -z "$infile" ]; then
       infile=$1
       if [ ! -f "$infile" ]; then
         echo "Inputfile '$infile' doesn't exist. Please check."
         exit 1
       fi
     else
-      if [ -z $outfile ]; then
+      if [ -z "$outfile" ]; then
         outfile=$1
       else
         echo "Error: too many parameters. Inputfile and Outputfile already defined. Please check your command."
@@ -119,7 +119,7 @@ if [[ ! -z "$workdir" ]]; then
     */)
       ;;
     *)
-      comskipoutput="--output=$workdir"
+      comskipoutput=--output="$workdir"
       workdir="$workdir/"
       ;;
   esac


### PR DESCRIPTION
Passing files with long, wordy paths & filenames was resulting in a variety of failures due to unescaped spaces. These quotation marks should keep everything where it belongs. Additionally Comskip was failing due to a param being passed in with double quotes around the whole thing instead of just its value. This has been resolved.