### PR TITLE
Add an exit code

### DIFF
--- a/comcut
+++ b/comcut
@@ -220,6 +220,8 @@ if $hascommercials ; then
   fi
 
   $ffmpegPath -hide_banner -loglevel error -nostdin -i "$metafile" -i "concat:${concat:1}" -c copy -map_metadata 0 -y "$outfile"
+else
+  exit 73
 fi
 
 for i in "${tempfiles[@]}"


### PR DESCRIPTION
When comcut is part of a larger process, inconsistently creating an output file can cause quite the headache. When exiting with 73, (i.e. EX_CANTCREAT -- A (user specified) output file cannot be created.) subsequent scripts can use that info to prevent trying to work on a non-existent file.

idk this may be a very wrong way to approach my problem—I don't write a lot of pure bash. But I definitely had one of those feelings like "I can't be the only one with this issue" when I was dealing with it so here we are.