### PR TITLE
faster seek time when cutting with FFmpeg

### DIFF
--- a/comcut
+++ b/comcut
@@ -181,7 +181,7 @@ do
     concat="$concat|$chapterfile"
 
     duration=`echo "$end" "$start" | awk  '{printf "%f", $1 - $2}'`
-    $ffmpegPath -hide_banner -loglevel error -nostdin -i "$infile" -ss "$start" -t "$duration" -c copy -y "$chapterfile"
+    $ffmpegPath -hide_banner -loglevel error -nostdin -ss "$start" -i "$infile" -t "$duration" -c copy -y "$chapterfile"
 
     totalcutduration=`echo "$totalcutduration" "$startnext" "$end" | awk  '{print $1 + $2 - $3}'`
 
@@ -216,7 +216,7 @@ if $hascommercials ; then
     concat="$concat|$chapterfile"
 
     duration=`echo "$end" "$start" | awk  '{printf "%f", $1 - $2}'`
-    $ffmpegPath -hide_banner -loglevel error -nostdin -i "$infile" -ss "$start" -t "$duration" -c copy -y "$chapterfile"
+    $ffmpegPath -hide_banner -loglevel error -nostdin -ss "$start" -i "$infile" -t "$duration" -c copy -y "$chapterfile"
   fi
 
   $ffmpegPath -hide_banner -loglevel error -nostdin -i "$metafile" -i "concat:${concat:1}" -c copy -map_metadata 0 -y "$outfile"


### PR DESCRIPTION
Apparently adding the "-ss" before "-i", fast seek is utilized. I'm seeing 2.5x faster cuts overall with this change.

Reference: https://trac.ffmpeg.org/wiki/Seeking#Cuttingsmallsections